### PR TITLE
skip_control_dims parameter in dim functions

### DIFF
--- a/TM1py/Services/DimensionService.py
+++ b/TM1py/Services/DimensionService.py
@@ -128,13 +128,20 @@ class DimensionService(ObjectService):
         url = format_url("/api/v1/Dimensions('{}')", dimension_name)
         return self._exists(url, **kwargs)
 
-    def get_all_names(self, **kwargs) -> List[str]:
-        """Ask TM1 Server for list with all dimension names
+    def get_all_names(self, skip_control_dims: bool = False, **kwargs) -> List[str]:
+        """Ask TM1 Server for list of all dimension names
 
+        :skip_control_dims: bool, True to skip control dims
         :Returns:
             List of Strings
         """
-        response = self._rest.GET(url='/api/v1/Dimensions?$select=Name', **kwargs)
+        url = format_url(
+            "/api/v1/{}?$select=Name",
+            'ModelDimensions()' if skip_control_dims else 'Dimensions'
+        )
+
+        response = self._rest.GET(url, **kwargs)
+
         dimension_names = list(entry['Name'] for entry in response.json()['value'])
         return dimension_names
 

--- a/TM1py/Services/DimensionService.py
+++ b/TM1py/Services/DimensionService.py
@@ -145,13 +145,19 @@ class DimensionService(ObjectService):
         dimension_names = list(entry['Name'] for entry in response.json()['value'])
         return dimension_names
 
-    def get_number_of_dimensions(self, **kwargs) -> int:
-        """Ask TM1 Server for the total number of dimensions
+    def get_number_of_dimensions(self, skip_control_dims: bool = False, **kwargs) -> int:
+        """Ask TM1 Server for number of dimensions
 
+        :skip_control_dims: bool, True to exclude control dims from count
         :return: Number of dimensions
         """
-        response = self._rest.GET(url='/api/v1/Dimensions/$count', **kwargs)
-        return int(response.text)
+
+        if skip_control_dims:
+            response = len(self.get_all_names(skip_control_dims=True, **kwargs))
+        else:
+            response = int(self._rest.GET("/api/v1/Dimensions/$count", **kwargs).text)
+        
+        return response
 
     def execute_mdx(self, dimension_name: str, mdx: str, **kwargs) -> List:
         """ Execute MDX against Dimension. 

--- a/Tests/DimensionService_test.py
+++ b/Tests/DimensionService_test.py
@@ -172,10 +172,12 @@ class TestDimensionService(unittest.TestCase):
 
     def test_get_all_names(self):
         self.assertIn(self.dimension_name, self.tm1.dimensions.get_all_names())
-
+        self.assertNotEqual(self.tm1.dimensions.get_all_names(), self.tm1.dimensions.get_all_names(skip_control_dims=True))
+        
     def test_get_number_of_dimensions(self):
         number_of_dimensions = self.tm1.dimensions.get_number_of_dimensions()
         self.assertIsInstance(number_of_dimensions, int)
+        self.assertNotEqual(self.tm1.dimensions.get_number_of_dimensions(), self.tm1.dimensions.get_number_of_dimensions(skip_control_dims=True))
 
     def test_execute_mdx(self):
         mdx = "{TM1SubsetAll(" + self.dimension_name + ")}"


### PR DESCRIPTION
I added skip_control_dims parameter to the get_all_names and get_number_of_dimensions functions and took a stab at the test cases.